### PR TITLE
Feature/launcher command

### DIFF
--- a/Payload.PlayStationClassic/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload.PlayStationClassic/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -80,6 +80,21 @@ launch_retroarch_standalone(){
   launch_retroarch --from_ui
 }
 
+launch_launcher_command(){
+  echo "[BLEEMSYNC](INFO) launching command from launch.sh"
+  if [ -f "/var/volatile/launchtmp/launch.sh" ]; then
+    chmod +x "/var/volatile/launchtmp/launch.sh"
+    killall -s KILL showLogo sonyapp ui_menu auto_dimmer pcsx sdl_display &> "/dev/null"
+    "/var/volatile/launchtmp/launch.sh"
+    echo "[BLEEMSYNC](INFO) launch.sh has exited with $?"
+  else
+    echo "[BLEEMSYNC](ERROR) launch.sh is missing"
+    echo "[BLEEMSYNC](DEBUG) launchtmp path: `readlink -fn /var/volatile/launchtmp/`"
+  fi
+  rm -f "/var/volatile/launchtmp"
+  echo launch_StockUI > "/tmp/launchfilecommand"
+}
+
 launch_BootMenu(){
   echo "[BLEEMSYNC](INFO) launching BootMenu"
   # Cleanup 

--- a/Payload.PlayStationClassic/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
+++ b/Payload.PlayStationClassic/bleemsync/etc/bleemsync/FUNC/0050_bleemsync.funcs
@@ -92,7 +92,10 @@ launch_launcher_command(){
     echo "[BLEEMSYNC](DEBUG) launchtmp path: `readlink -fn /var/volatile/launchtmp/`"
   fi
   rm -f "/var/volatile/launchtmp"
-  echo launch_StockUI > "/tmp/launchfilecommand"
+  if [ ! -f /tmp/launchfilecommand ]; then
+    # If no further launchfilecommand has been set then return to StockUI
+    echo launch_StockUI > "/tmp/launchfilecommand"
+  fi
 }
 
 launch_BootMenu(){

--- a/Payload.PlayStationClassic/bleemsync/etc/bleemsync/SUP/launchers/bootmenu_launch/launch.sh
+++ b/Payload.PlayStationClassic/bleemsync/etc/bleemsync/SUP/launchers/bootmenu_launch/launch.sh
@@ -1,4 +1,2 @@
 #!/bin/sh
 echo "launch_BootMenu" > "/tmp/launchfilecommand"
-touch "/tmp/weston_need_restart.flag"
-touch "/data/power/prepare_suspend"

--- a/Payload.PlayStationClassic/bleemsync/etc/bleemsync/SUP/launchers/retroarch_launch/launch.sh
+++ b/Payload.PlayStationClassic/bleemsync/etc/bleemsync/SUP/launchers/retroarch_launch/launch.sh
@@ -1,4 +1,2 @@
 #!/bin/sh
 echo "launch_retroarch_standalone" > "/tmp/launchfilecommand"
-touch "/tmp/weston_need_restart.flag"
-touch "/data/power/prepare_suspend"

--- a/Payload.PlayStationClassic/bleemsync/etc/bleemsync/SUP/scripts/intercept
+++ b/Payload.PlayStationClassic/bleemsync/etc/bleemsync/SUP/scripts/intercept
@@ -85,7 +85,10 @@ echo "[INTERCEPT](INFO) Starting PS Classic Intercept"
 # If launch script exists run it instead of pcsx/RA
 if [ -f "/data/AppData/sony/title/launch.sh" ]; then
   echo "[INTERCEPT](INFO) launch.sh exists"
-  exec "/data/AppData/sony/title/launch.sh" 
+  title_path=`readlink -fn /data/AppData/sony/title/`
+  ln -sf "$title_path" "/var/volatile/launchtmp"
+  echo "launch_launcher_command" > "/tmp/launchfilecommand"
+  touch "/data/power/prepare_suspend"
   # Shouldn't get to here
   exit 1
 fi

--- a/Payload.PlayStationClassic/bleemsync/etc/bleemsync/SUP/scripts/intercept
+++ b/Payload.PlayStationClassic/bleemsync/etc/bleemsync/SUP/scripts/intercept
@@ -20,15 +20,6 @@
 # ModMyClassic.com / https://discordapp.com/invite/8gygsrw
 ###############################################################################
 
-### CHECK FOR LAUNCH SCRIPT ###################################################
-# If launch script exists run it instead of pcsx/RA
-if [ -f "/data/AppData/sony/title/launch.sh" ]; then
-  echo "[INTERCEPT](INFO) launch.sh exists"
-  exec "/data/AppData/sony/title/launch.sh" 
-  # Shouldn't get to here
-  exit 1
-fi
-
 start=$(date +%s%N)
 ### LOAD CONFIGURATION ########################################################
 source "/var/volatile/bleemsync.cfg"
@@ -89,6 +80,16 @@ resume_ui_menu() {
 # with the path to this script
 ###############################################################################
 echo "[INTERCEPT](INFO) Starting PS Classic Intercept"
+
+### CHECK FOR LAUNCH SCRIPT ###################################################
+# If launch script exists run it instead of pcsx/RA
+if [ -f "/data/AppData/sony/title/launch.sh" ]; then
+  echo "[INTERCEPT](INFO) launch.sh exists"
+  exec "/data/AppData/sony/title/launch.sh" 
+  # Shouldn't get to here
+  exit 1
+fi
+
 if [ "$#" -ge 1 ]; then
   echo "[INTERCEPT](INFO) There are $# parameters:"
   echo "[INTERCEPT](INFO) $*"


### PR DESCRIPTION
Modifications of intercept script to move the execution of launch.sh from there to the launchfilecommand function in 0050_bleemsync.funcs.

A new symlink is created from `/data/AppData/sony/title/` to `/var/volatile/launchtmp` so that the files of the launcher (and launch.sh) can be easily accessed once ui_menu has exited.

